### PR TITLE
[feature] Optional AML replicaset feature in openmp-threading.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ XSBench is a mini-app representing a key computational kernel of the Monte Carlo
 3. [Running XSBench / Command Line Interface](#Running-XSBench)
 4. [Feature Discussion](#Feature-Discussion)
 	* [MPI Support](#MPI-Support)
+	* [AML Optimizations](#AML-Optimizations)
 	* [Verification Support](#Verification-Support)
 	* [Binary File Support](#Binary-File-Support)
 5. [Theory & Algorithms](#Algorithms)
@@ -69,6 +70,7 @@ OPTIMIZE = yes
 DEBUG    = no
 PROFILE  = no
 MPI      = no
+AML      = no
 ```
 - Optimization enables the -O3 optimization flag.
 - Debugging enables the -g flag.
@@ -76,6 +78,7 @@ MPI      = no
 wish to significantly increase the number of lookups (with the -l
 flag) in order to wash out the initialization phase of the code.
 - MPI enables MPI support in the code.
+- AML enables AML optimizations. See [AML Optimizations](#AML-Optimizations).
 
 ## Running XSBench
 
@@ -133,6 +136,18 @@ For some of the XSBench code-bases (e.g., openmp-threading and cuda) there are s
 ### MPI Support
 
 While XSBench is primarily used to investigate "on node parallelism" issues, some systems provide power & performance statistics batched in multi-node configurations. To accommodate this, XSBench provides an MPI mode which runs the code on all MPI ranks simultaneously. There is no decomposition across ranks of any kind, and all ranks accomplish the same work. This is a "weak scaling" approach -- for instance, if running the event-based model all MPI ranks will execute 17,000,000 cross section lookups regardless of how many ranks are used. There is only one point of MPI communication (a reduce) at the end, which aggregates the timing statistics and averages them across MPI ranks before printing them out. MPI support can be enabled with the makefile flag "MPI". If you are not using the mpicc wrapper on your system, you may need to alter the makefile to make use of your desired compiler.
+
+### AML Optimizations
+
+AML is a memory management library featuring optimization abtractions. More information about the library can be found in the [online documentation](https://argo-aml.readthedocs.io/en/latest/). The library can be downloaded and installed from the [repository](https://xgitlab.cels.anl.gov/argo/aml).
+
+XSBench can be compiled to include these optimizations by toggling `make` `AML=yes` option. In order for `pkg-config` to find out the appropriate compilation flags, environment variable `PKG_CONFIG_PATH` must point to the install directory of `aml.pc`.
+
+Current optimizations featured in XSBench are as follow:
+- **replicaset**: Performance sensitive data structures are replicated on memories close to processing elements. If a group of processing elements have several close memories (e.g a NUMA cluster on Intel Knights Landing processor with has both a MCDRAM and DRAM memory modules) then the memory with the smallest latency is elected. Upon accessing sensitive data, the accessor location is looked up and the closest replica (latency wise) is accessed.
+
+Optimizations implementation and availability may depend on the programming model. In the current version the following programming models feature AML optimizations:
+- **openmp-threading**: replicaset.
 
 ### Verification Support
 

--- a/openmp-threading/GridInit.c
+++ b/openmp-threading/GridInit.c
@@ -170,8 +170,58 @@ SimulationData grid_init_do_not_profile( Inputs in, int mype )
 	SD.concs = load_concs(SD.num_nucs, SD.max_num_nucs);
 	SD.length_concs = SD.length_mats;
 
+	// Allocate and initialize replicas
+#ifdef AML
+	// num_nucs
+	aml_replicaset_hwloc_create(&(SD.num_nucs_replica),
+															SD.length_num_nucs * sizeof(*(SD.num_nucs)),
+															HWLOC_OBJ_CORE,
+															HWLOC_DISTANCES_KIND_FROM_OS |
+															HWLOC_DISTANCES_KIND_MEANS_LATENCY);
+	nbytes += (SD.num_nucs_replica)->n * (SD.num_nucs_replica)->size;
+	aml_replicaset_init(SD.num_nucs_replica, SD.num_nucs);
+
+	// concs
+	aml_replicaset_hwloc_create(&(SD.concs_replica),
+															SD.length_concs * sizeof(*(SD.concs)),
+															HWLOC_OBJ_CORE,
+															HWLOC_DISTANCES_KIND_FROM_OS |
+															HWLOC_DISTANCES_KIND_MEANS_LATENCY);
+	nbytes += (SD.concs_replica)->n * (SD.concs_replica)->size;
+	aml_replicaset_init(SD.concs_replica, SD.concs);
+
+	// unionized_energy_array
+	if( in.grid_type == UNIONIZED ){
+		aml_replicaset_hwloc_create(&(SD.unionized_energy_array_replica),
+																SD.length_unionized_energy_array * sizeof(*(SD.unionized_energy_array)),
+																HWLOC_OBJ_CORE,
+																HWLOC_DISTANCES_KIND_FROM_OS |
+																HWLOC_DISTANCES_KIND_MEANS_LATENCY);
+		nbytes += (SD.unionized_energy_array_replica)->n * (SD.unionized_energy_array_replica)->size;
+		aml_replicaset_init(SD.unionized_energy_array_replica, SD.unionized_energy_array);
+	}
+
+	// index grid
+	if( in.grid_type == UNIONIZED || in.grid_type == HASH ){
+		aml_replicaset_hwloc_create(&(SD.index_grid_replica),
+																SD.length_index_grid * sizeof(*(SD.index_grid)),
+																HWLOC_OBJ_CORE,
+																HWLOC_DISTANCES_KIND_FROM_OS |
+																HWLOC_DISTANCES_KIND_MEANS_LATENCY);
+		nbytes += (SD.index_grid_replica)->n * (SD.index_grid_replica)->size;
+		aml_replicaset_init(SD.index_grid_replica, SD.index_grid);
+	}
+
+	// nuclide grid
+	aml_replicaset_hwloc_create(&(SD.nuclide_grid_replica),
+															SD.length_nuclide_grid * sizeof(*(SD.nuclide_grid)),
+															HWLOC_OBJ_CORE,
+															HWLOC_DISTANCES_KIND_FROM_OS |
+															HWLOC_DISTANCES_KIND_MEANS_LATENCY);
+	nbytes += (SD.nuclide_grid_replica)->n * (SD.nuclide_grid_replica)->size;
+	aml_replicaset_init(SD.nuclide_grid_replica, SD.nuclide_grid);
+#endif
+	
 	if(mype == 0) printf("Intialization complete. Allocated %.0lf MB of data.\n", nbytes/1024.0/1024.0 );
-
 	return SD;
-
 }

--- a/openmp-threading/Main.c
+++ b/openmp-threading/Main.c
@@ -21,6 +21,10 @@ int main( int argc, char* argv[] )
 	MPI_Comm_rank(MPI_COMM_WORLD, &mype);
 	#endif
 
+	#ifdef AML
+	aml_init(&argc, &argv);
+	#endif
+
 	// Process CLI Fields -- store in "Inputs" structure
 	Inputs in = read_CLI( argc, argv );
 
@@ -109,6 +113,10 @@ int main( int argc, char* argv[] )
 
 	#ifdef MPI
 	MPI_Finalize();
+	#endif
+
+	#ifdef AML
+	aml_finalize();
 	#endif
 
 	return is_invalid_result;

--- a/openmp-threading/Makefile
+++ b/openmp-threading/Makefile
@@ -11,6 +11,7 @@ OPENMP      = yes
 DEBUG       = no
 PROFILE     = no
 MPI         = no
+AML         = no
 
 #===============================================================================
 # Program name & source code list
@@ -88,6 +89,12 @@ endif
 ifeq ($(MPI),yes)
   CC = mpicc
   CFLAGS += -DMPI
+endif
+
+# AML
+ifeq ($(AML),yes)
+  LDFLAGS += $(shell pkg-config --libs aml) -lhwloc
+  CFLAGS += -DAML
 endif
 
 #===============================================================================

--- a/openmp-threading/Makefile
+++ b/openmp-threading/Makefile
@@ -93,8 +93,8 @@ endif
 
 # AML
 ifeq ($(AML),yes)
-  LDFLAGS += $(shell pkg-config --libs aml) -lhwloc
-  CFLAGS += -DAML
+  LDFLAGS += $(shell pkg-config --libs aml)
+  CFLAGS += -DAML $(shell pkg-config --cflags aml)
 endif
 
 #===============================================================================

--- a/openmp-threading/Simulation.c
+++ b/openmp-threading/Simulation.c
@@ -44,6 +44,20 @@ unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int 
 	#pragma omp parallel for schedule(dynamic,100) reduction(+:verification)
 	for( int i = 0; i < in.lookups; i++ )
 	{
+		#ifdef AML
+		int * num_nucs = aml_replicaset_hwloc_local_replica(SD.num_nucs_replica);
+		double * concs = aml_replicaset_hwloc_local_replica(SD.concs_replica);
+		double * unionized_energy_array = aml_replicaset_hwloc_local_replica(SD.unionized_energy_array_replica);
+		int * index_grid = aml_replicaset_hwloc_local_replica(SD.index_grid_replica);
+		NuclideGridPoint * nuclide_grid = aml_replicaset_hwloc_local_replica(SD.nuclide_grid_replica);
+		#else
+		int * num_nucs = SD.num_nucs;
+		double * concs = SD.concs;
+		double * unionized_energy_array = SD.unionized_energy_array;
+		int * index_grid = SD.index_grid;
+		NuclideGridPoint * nuclide_grid = SD.nuclide_grid;
+		#endif
+
 		// Set the initial seed value
 		uint64_t seed = STARTING_SEED;	
 
@@ -62,11 +76,11 @@ unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int 
 				mat,             // Sampled material type index neutron is in
 				in.n_isotopes,   // Total number of isotopes in simulation
 				in.n_gridpoints, // Number of gridpoints per isotope in simulation
-				SD.num_nucs,     // 1-D array with number of nuclides per material
-				SD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
-				SD.unionized_energy_array, // 1-D Unionized energy array
-				SD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
-				SD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+				num_nucs,     // 1-D array with number of nuclides per material
+				concs,        // Flattened 2-D array with concentration of each nuclide in each material
+				unionized_energy_array, // 1-D Unionized energy array
+				index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+				nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
 				SD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
 				macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
 				in.grid_type,    // Lookup type (nuclide, hash, or unionized)
@@ -129,6 +143,20 @@ unsigned long long run_history_based_simulation(Inputs in, SimulationData SD, in
 	#pragma omp parallel for schedule(dynamic, 100) reduction(+:verification)
 	for( int p = 0; p < in.particles; p++ )
 	{
+		#ifdef AML
+		int * num_nucs = aml_replicaset_hwloc_local_replica(SD.num_nucs_replica);
+		double * concs = aml_replicaset_hwloc_local_replica(SD.concs_replica);
+		double * unionized_energy_array = aml_replicaset_hwloc_local_replica(SD.unionized_energy_array_replica);
+		int * index_grid = aml_replicaset_hwloc_local_replica(SD.index_grid_replica);
+		NuclideGridPoint * nuclide_grid = aml_replicaset_hwloc_local_replica(SD.nuclide_grid_replica);
+		#else
+		int * num_nucs = SD.num_nucs;
+		double * concs = SD.concs;
+		double * unionized_energy_array = SD.unionized_energy_array;
+		int * index_grid = SD.index_grid;
+		NuclideGridPoint * nuclide_grid = SD.nuclide_grid;
+		#endif
+
 		// Set the initial seed value
 		uint64_t seed = STARTING_SEED;	
 
@@ -153,11 +181,11 @@ unsigned long long run_history_based_simulation(Inputs in, SimulationData SD, in
 					mat,             // Sampled material type neutron is in
 					in.n_isotopes,   // Total number of isotopes in simulation
 					in.n_gridpoints, // Number of gridpoints per isotope in simulation
-					SD.num_nucs,     // 1-D array with number of nuclides per material
-					SD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
-					SD.unionized_energy_array, // 1-D Unionized energy array
-					SD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
-					SD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+					num_nucs,     // 1-D array with number of nuclides per material
+					concs,        // Flattened 2-D array with concentration of each nuclide in each material
+					unionized_energy_array, // 1-D Unionized energy array
+					index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+					nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
 					SD.mats,         // Flattened 2-D array with nuclide indices for each type of material
 					macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
 					in.grid_type,    // Lookup type (nuclide, hash, or unionized)
@@ -770,6 +798,20 @@ unsigned long long run_event_based_simulation_optimization_1(Inputs in, Simulati
 		#pragma omp parallel for schedule(dynamic,100) reduction(+:verification)
 		for( int i = offset; i < offset + num_samples_per_mat[m]; i++)
 		{
+			#ifdef AML
+			int * num_nucs = aml_replicaset_hwloc_local_replica(SD.num_nucs_replica);
+			double * concs = aml_replicaset_hwloc_local_replica(SD.concs_replica);
+			double * unionized_energy_array = aml_replicaset_hwloc_local_replica(SD.unionized_energy_array_replica);
+			int * index_grid = aml_replicaset_hwloc_local_replica(SD.index_grid_replica);
+			NuclideGridPoint * nuclide_grid = aml_replicaset_hwloc_local_replica(SD.nuclide_grid_replica);
+			#else
+			int * num_nucs = SD.num_nucs;
+			double * concs = SD.concs;
+			double * unionized_energy_array = SD.unionized_energy_array;
+			int * index_grid = SD.index_grid;
+			NuclideGridPoint * nuclide_grid = SD.nuclide_grid;
+			#endif
+
 			// load pre-sampled energy and material for the particle
 			double p_energy = SD.p_energy_samples[i];
 			int mat         = SD.mat_samples[i]; 
@@ -782,11 +824,11 @@ unsigned long long run_event_based_simulation_optimization_1(Inputs in, Simulati
 					mat,             // Sampled material type index neutron is in
 					in.n_isotopes,   // Total number of isotopes in simulation
 					in.n_gridpoints, // Number of gridpoints per isotope in simulation
-					SD.num_nucs,     // 1-D array with number of nuclides per material
-					SD.concs,        // Flattened 2-D array with concentration of each nuclide in each material
-					SD.unionized_energy_array, // 1-D Unionized energy array
-					SD.index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
-					SD.nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
+					num_nucs,     // 1-D array with number of nuclides per material
+					concs,        // Flattened 2-D array with concentration of each nuclide in each material
+					unionized_energy_array, // 1-D Unionized energy array
+					index_grid,   // Flattened 2-D grid holding indices into nuclide grid for each unionized energy level
+					nuclide_grid, // Flattened 2-D grid holding energy levels and XS_data for all nuclides in simulation
 					SD.mats,         // Flattened 2-D array with nuclide indices defining composition of each type of material
 					macro_xs_vector, // 1-D array with result of the macroscopic cross section (5 different reaction channels)
 					in.grid_type,    // Lookup type (nuclide, hash, or unionized)

--- a/openmp-threading/XSbench_header.h
+++ b/openmp-threading/XSbench_header.h
@@ -21,6 +21,13 @@
 #include "papi.h"
 #endif
 
+//AML header
+#ifdef AML
+#include<aml.h>
+#include<aml/higher/replicaset/replicaset.h>
+#include<aml/higher/replicaset/hwloc.h>
+#endif
+
 // Grid types
 #define UNIONIZED 0
 #define NUCLIDE 1
@@ -69,6 +76,13 @@ typedef struct{
 	double * unionized_energy_array;    // Length = length_unionized_energy_array
 	int * index_grid;                   // Length = length_index_grid
 	NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
+#ifdef AML
+	struct aml_replicaset * num_nucs_replica;
+	struct aml_replicaset * concs_replica;
+	struct aml_replicaset * unionized_energy_array_replica;
+	struct aml_replicaset * index_grid_replica;
+	struct aml_replicaset * nuclide_grid_replica;
+#endif
 	int length_num_nucs;
 	int length_concs;
 	int length_mats;


### PR DESCRIPTION
This merge requests will include a compilation option to enable use of one AML feature.
Upon activation, main data arrays will be replicated and threads will access data on the closest memory bank (latency wise).
This option applies only to `openmp-threading` version.
 