### PR TITLE
AML Mapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,9 @@ While XSBench is primarily used to investigate "on node parallelism" issues, som
 
 AML is a memory management library featuring optimization abtractions. More information about the library can be found in the [online documentation](https://argo-aml.readthedocs.io/en/latest/). The library can be downloaded and installed from the [repository](https://xgitlab.cels.anl.gov/argo/aml).
 
-XSBench can be compiled to include these optimizations by toggling `make` `AML=yes` option. In order for `pkg-config` to find out the appropriate compilation flags, environment variable `PKG_CONFIG_PATH` must point to the install directory of `aml.pc`.
+XSBench can be compiled to include these optimizations by toggling `make` `AML=yes` option.  
+The current supported version of AML is commit: `ec81063961f2968a6fc051438bcae3dba0084b17`.  
+In order for `pkg-config` to find the appropriate compilation flags, the environment variable `PKG_CONFIG_PATH` must point to the install directory of `aml.pc`, usually in `<INSTALL_PRREFIX>/lib/pkgconfig`.
 
 Current optimizations featured in XSBench are as follow:
 - **replicaset**: Performance sensitive data structures are replicated on memories close to processing elements. If a group of processing elements have several close memories (e.g a NUMA cluster on Intel Knights Landing processor with has both a MCDRAM and DRAM memory modules) then the memory with the smallest latency is elected. Upon accessing sensitive data, the accessor location is looked up and the closest replica (latency wise) is accessed.

--- a/README.md
+++ b/README.md
@@ -146,8 +146,15 @@ XSBench can be compiled to include these optimizations by toggling `make` `AML=y
 Current optimizations featured in XSBench are as follow:
 - **replicaset**: Performance sensitive data structures are replicated on memories close to processing elements. If a group of processing elements have several close memories (e.g a NUMA cluster on Intel Knights Landing processor with has both a MCDRAM and DRAM memory modules) then the memory with the smallest latency is elected. Upon accessing sensitive data, the accessor location is looked up and the closest replica (latency wise) is accessed.
 
+- **mapper**: AML mapper provides abstractions to describe the layout of a hierarchical data structure and deepcopy it into a target memory. Complex data structure that needs to be 
+copied on a cuda device can be copied with less code and inside a contiguous memory area.
+Therefore, this optimization moves the complexity of managing deep data copies into the 
+AML library.
+
 Optimizations implementation and availability may depend on the programming model. In the current version the following programming models feature AML optimizations:
 - **openmp-threading**: replicaset.
+- **cuda**: mapper.
+- **openmp-offload**: mapper using level zero backend for allocation and movements.
 
 ### Verification Support
 

--- a/cuda/GridInit.cu
+++ b/cuda/GridInit.cu
@@ -23,11 +23,19 @@ SimulationData move_simulation_data_to_device( Inputs in, int mype, SimulationDa
 	// Note: "Lengths" are given as the number of objects in the array, not the
 	//       number of bytes.
 	////////////////////////////////////////////////////////////////////////////////
-	size_t sz;
-	size_t total_sz = 0;
 
 	// Shallow copy of CPU simulation data to GPU simulation data
 	SimulationData GSD = SD;
+#ifdef AML
+	// Deep copy  of CPU simulation data to GPU simulation data
+	assert(aml_mapper_mmap(&SimulationData_mapper,
+												 &SD, &GSD, 1, &aml_area_cuda, NULL,
+												 &aml_dma_cuda_host_to_device,
+												 aml_dma_cuda_copy_1D,
+												 NULL) == AML_SUCCESS);
+#else
+	size_t total_sz = 0;
+	size_t sz;
 
 	// Move data to GPU memory space
 	sz = GSD.length_num_nucs * sizeof(int);
@@ -66,12 +74,14 @@ SimulationData move_simulation_data_to_device( Inputs in, int mype, SimulationDa
 	gpuErrchk( cudaMalloc((void **) &GSD.verification, sz) );
 	total_sz += sz;
 	GSD.length_verification = in.lookups;
+#endif
 	
 	// Synchronize
 	gpuErrchk( cudaPeekAtLastError() );
 	gpuErrchk( cudaDeviceSynchronize() );
-	
+#ifndef AML
 	if(mype == 0 ) printf("GPU Intialization complete. Allocated %.0lf MB of data on GPU.\n", total_sz/1024.0/1024.0 );
+#endif
 
 	return GSD;
 
@@ -110,7 +120,7 @@ SimulationData grid_init_do_not_profile( Inputs in, int mype )
 	SD.nuclide_grid     = (NuclideGridPoint *) malloc( SD.length_nuclide_grid * sizeof(NuclideGridPoint));
 	assert(SD.nuclide_grid != NULL);
 	nbytes += SD.length_nuclide_grid * sizeof(NuclideGridPoint);
-	for( int i = 0; i < SD.length_nuclide_grid; i++ )
+	for( size_t i = 0; i < SD.length_nuclide_grid; i++ )
 	{
 		SD.nuclide_grid[i].energy        = LCG_random_double(&seed);
 		SD.nuclide_grid[i].total_xs      = LCG_random_double(&seed);
@@ -156,7 +166,7 @@ SimulationData grid_init_do_not_profile( Inputs in, int mype )
 		nbytes += SD.length_unionized_energy_array * sizeof(double);
 
 		// Copy energy data over from the nuclide energy grid
-		for( int i = 0; i < SD.length_unionized_energy_array; i++ )
+		for( size_t i = 0; i < SD.length_unionized_energy_array; i++ )
 			SD.unionized_energy_array[i] = SD.nuclide_grid[i].energy;
 
 		// Sort unionized energy array
@@ -177,7 +187,7 @@ SimulationData grid_init_do_not_profile( Inputs in, int mype )
 		for( int i = 0; i < in.n_isotopes; i++ )
 			energy_high[i] = SD.nuclide_grid[i * in.n_gridpoints + 1].energy;
 
-		for( long e = 0; e < SD.length_unionized_energy_array; e++ )
+		for( size_t e = 0; e < SD.length_unionized_energy_array; e++ )
 		{
 			double unionized_energy = SD.unionized_energy_array[e];
 			for( long i = 0; i < in.n_isotopes; i++ )

--- a/cuda/Main.cu
+++ b/cuda/Main.cu
@@ -1,4 +1,7 @@
 #include "XSbench_header.cuh"
+#ifdef AML
+#include "aml.cu"
+#endif
 
 int main( int argc, char* argv[] )
 {
@@ -11,6 +14,10 @@ int main( int argc, char* argv[] )
 	int nprocs = 1;
 	unsigned long long verification;
 
+	#ifdef AML
+	if (aml_init(&argc, &argv) != AML_SUCCESS)
+		return 1;
+	#endif
 	// Process CLI Fields -- store in "Inputs" structure
 	Inputs in = read_CLI( argc, argv );
 
@@ -32,6 +39,8 @@ int main( int argc, char* argv[] )
 		SD = binary_read(in);
 	else
 		SD = grid_init_do_not_profile( in, mype );
+	SD.length_mat_samples = in.lookups;
+	SD.length_p_energy_samples = in.lookups;
 
 	// If writing from file mode is selected, write all simulation data
 	// structures to file
@@ -102,5 +111,8 @@ int main( int argc, char* argv[] )
 	// Print / Save Results and Exit
 	int is_invalid_result = print_results( in, mype, omp_end-omp_start, nprocs, verification );
 
+	#ifdef AML
+	aml_finalize();
+	#endif
 	return is_invalid_result;
 }

--- a/cuda/Makefile
+++ b/cuda/Makefile
@@ -7,6 +7,7 @@ OPTIMIZE    = yes
 DEBUG       = no
 PROFILE     = no
 SM_VERSION  = 70
+AML         = no
 
 #===============================================================================
 # Program name & source code list
@@ -55,6 +56,12 @@ endif
 # Optimization Flags
 ifeq ($(OPTIMIZE),yes)
   CFLAGS += -O3
+endif
+
+# AML
+ifeq ($(AML),yes)
+  LDFLAGS += $(shell pkg-config --libs aml)
+  CFLAGS += -I$(HOME)/local/include -DAML $(shell pkg-config --cflags aml)
 endif
 
 #===============================================================================

--- a/cuda/XSbench_header.cuh
+++ b/cuda/XSbench_header.cuh
@@ -68,19 +68,19 @@ typedef struct{
 	double * unionized_energy_array;    // Length = length_unionized_energy_array
 	int * index_grid;                   // Length = length_index_grid
 	NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
-	int length_num_nucs;
-	int length_concs;
-	int length_mats;
-	int length_unionized_energy_array;
-	long length_index_grid;
-	int length_nuclide_grid;
+	size_t length_num_nucs;
+	size_t length_concs;
+	size_t length_mats;
+	size_t length_unionized_energy_array;
+	size_t length_index_grid;
+	size_t length_nuclide_grid;
 	int max_num_nucs;
 	unsigned long * verification;
-	int length_verification;
+	size_t length_verification;
 	double * p_energy_samples;
-	int length_p_energy_samples;
+	size_t length_p_energy_samples;
 	int * mat_samples;
-	int length_mat_samples;
+	size_t length_mat_samples;
 } SimulationData;
 
 // io.cu
@@ -149,4 +149,14 @@ double get_time(void);
 int * load_num_nucs(long n_isotopes);
 int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs );
 double * load_concs( int * num_nucs, int max_num_nucs );
+
+#ifdef AML
+#include<aml.h>
+#include<aml/higher/mapper.h>
+#include<aml/area/cuda.h>
+#include<aml/dma/cuda.h>
+
+extern struct aml_mapper SimulationData_mapper;
+#endif // AML
+
 #endif

--- a/cuda/aml.cu
+++ b/cuda/aml.cu
@@ -1,0 +1,34 @@
+// Separate allocation and copy element of NuclideGridPoint
+static aml_final_mapper_decl(NuclideGridPoint_mapper,
+														 AML_MAPPER_FLAG_SPLIT,
+                             NuclideGridPoint);
+
+// Separate allocation and copy element of int arrays.
+static aml_final_mapper_decl(int_copy_mapper,
+														 AML_MAPPER_FLAG_SPLIT,
+														 int);
+// Separate allocation but no copy element of int arrays.
+static aml_final_mapper_decl(int_alloc_mapper, AML_MAPPER_FLAG_SPLIT, int);
+
+// Bulk allocation and copy element of double arrays.
+static aml_final_mapper_decl(double_copy_mapper, 0, double);
+// Bulk allocation and but no copy of double arrays.
+static aml_final_mapper_decl(double_alloc_mapper, 0, double);
+// Separate allocation but no copy element of unsigned long arrays.
+static aml_final_mapper_decl(ulong_alloc_mapper, AML_MAPPER_FLAG_SPLIT, unsigned long);
+
+// Top level structure.
+// Copy but do not allocate.
+// The pointer with space will be provided. Only child fields will require
+// allocation.
+aml_mapper_decl(SimulationData_mapper,
+							  AML_MAPPER_FLAG_SHALLOW,
+								SimulationData,
+								num_nucs, length_num_nucs, &int_copy_mapper,
+								concs, length_concs, &double_copy_mapper,
+								mats, length_mats, &int_copy_mapper,
+								unionized_energy_array, length_unionized_energy_array, &double_copy_mapper,
+								index_grid, length_index_grid, &int_copy_mapper,
+								nuclide_grid, length_nuclide_grid, &NuclideGridPoint_mapper,
+								verification, length_verification, &ulong_alloc_mapper,
+								p_energy_samples, length_p_energy_samples, &double_alloc_mapper);

--- a/openmp-offload/Makefile
+++ b/openmp-offload/Makefile
@@ -7,6 +7,7 @@ OPTIMIZE    = yes
 DEBUG       = no
 PROFILE     = no
 MPI         = no
+AML         = no
 
 #===============================================================================
 # Program name & source code list
@@ -79,6 +80,12 @@ endif
 ifeq ($(MPI),yes)
   CC = mpicc
   CFLAGS += -DMPI
+endif
+
+# AML
+ifeq ($(AML),yes)
+  LDFLAGS += $(shell pkg-config --libs aml)
+  CFLAGS += -DAML $(shell pkg-config --cflags aml)
 endif
 
 #===============================================================================

--- a/openmp-offload/XSbench_header.h
+++ b/openmp-offload/XSbench_header.h
@@ -66,17 +66,17 @@ typedef struct{
 	double * unionized_energy_array;    // Length = length_unionized_energy_array
 	int * index_grid;                   // Length = length_index_grid
 	NuclideGridPoint * nuclide_grid;    // Length = length_nuclide_grid
-	int length_num_nucs;
-	int length_concs;
-	int length_mats;
-	int length_unionized_energy_array;
-	long length_index_grid;
-	int length_nuclide_grid;
+	size_t length_num_nucs;
+  size_t length_concs;
+  size_t length_mats;
+  size_t length_unionized_energy_array;
+  size_t length_index_grid;
+  size_t length_nuclide_grid;
 	int max_num_nucs;
 	double * p_energy_samples;
-	int length_p_energy_samples;
+  size_t length_p_energy_samples;
 	int * mat_samples;
-	int length_mat_samples;
+  size_t length_mat_samples;
 } SimulationData;
 
 // io.c
@@ -125,4 +125,14 @@ size_t estimate_mem_usage( Inputs in );
 int * load_num_nucs(long n_isotopes);
 int * load_mats( int * num_nucs, long n_isotopes, int * max_num_nucs );
 double * load_concs( int * num_nucs, int max_num_nucs );
+
+#ifdef AML
+#include<aml.h>
+#include<aml/higher/mapper.h>
+#include<aml/area/ze.h>
+#include<aml/dma/ze.h>
+
+extern struct aml_mapper SimulationData_mapper;
+#endif // AML
+
 #endif

--- a/openmp-offload/aml.c
+++ b/openmp-offload/aml.c
@@ -1,0 +1,29 @@
+// Separate allocation and copy element of NuclideGridPoint
+static aml_final_mapper_decl(NuclideGridPoint_mapper,
+														 AML_MAPPER_FLAG_SPLIT,
+                             NuclideGridPoint);
+
+// Separate allocation but no copy element of int arrays.
+static aml_final_mapper_decl(int_alloc_mapper, AML_MAPPER_FLAG_SPLIT, int);
+
+// Bulk allocation and copy element of double arrays.
+static aml_final_mapper_decl(double_copy_mapper, 0, double);
+// Bulk allocation and but no copy of double arrays.
+static aml_final_mapper_decl(double_alloc_mapper, 0, double);
+// Separate allocation but no copy element of unsigned long arrays.
+static aml_final_mapper_decl(ulong_alloc_mapper, AML_MAPPER_FLAG_SPLIT, unsigned long);
+
+// Top level structure.
+// Copy but do not allocate.
+// The pointer with space will be provided. Only child fields will require
+// allocation.
+aml_mapper_decl(SimulationData_mapper,
+                AML_MAPPER_FLAG_SHALLOW, SimulationData,
+                num_nucs, length_num_nucs, &int_alloc_mapper,
+								concs, length_concs, &double_copy_mapper,
+								mats, length_mats, &int_alloc_mapper,
+								unionized_energy_array, length_unionized_energy_array, &double_copy_mapper,
+								index_grid, length_index_grid, &int_alloc_mapper,
+								nuclide_grid, length_nuclide_grid, &NuclideGridPoint_mapper,
+								p_energy_samples, length_p_energy_samples, &double_alloc_mapper,
+								mat_samples, length_mat_samples, &int_alloc_mapper);


### PR DESCRIPTION
This merge requests adds demonstration implementations of XSBench using AML mapper feature.
`README.md` provides more detail on the feature itself.
The feature is used both to alter `openmp-offload` and `cuda` versions of the code.

The exact commit tag when the feature has been tested to work is documented in the README.
In the future, we plan to run every CI pipeline of AML with an integration test on these features in the similar way
we did for the replicaset feature in XSBench. We will also update supported versions or commit tags of AML supporting
the features.


