### PR TITLE
For OpenCL build add -lOpenCL to LDFLAGS.

### DIFF
--- a/opencl/Makefile
+++ b/opencl/Makefile
@@ -38,7 +38,7 @@ LDFLAGS = -lm
 # Regular gcc Compiler
 ifeq ($(COMPILER),gnu)
   CC = gcc
-  CFLAGS += -lOpenCL
+  LDFLAGS += -lOpenCL
 endif
 
 # Intel Compiler


### PR DESCRIPTION
This got XSBench linking on my GNU Linux system without a bunch of `undefined reference` errors from `ld`.