### PR TITLE
Release CUDA device memory after computation

### DIFF
--- a/cuda/GridInit.cu
+++ b/cuda/GridInit.cu
@@ -77,6 +77,16 @@ SimulationData move_simulation_data_to_device( Inputs in, int mype, SimulationDa
 
 }
 
+// Release device memory
+void release_device_memory(SimulationData GSD) {
+	cudaFree(GSD.num_nucs);
+	cudaFree(GSD.concs);
+	cudaFree(GSD.mats);
+	cudaFree(GSD.unionized_energy_array);
+	cudaFree(GSD.nuclide_grid);
+	cudaFree(GSD.verification);
+}
+
 SimulationData grid_init_do_not_profile( Inputs in, int mype )
 {
 	// Structure to hold all allocated simuluation data arrays

--- a/cuda/Main.cu
+++ b/cuda/Main.cu
@@ -96,6 +96,9 @@ int main( int argc, char* argv[] )
 	// End Simulation Timer
 	omp_end = get_time();
 
+	// Release device memory
+	release_device_memory(GSD);
+
 	// Final Hash Step
 	verification = verification % 999983;
 

--- a/cuda/XSbench_header.cuh
+++ b/cuda/XSbench_header.cuh
@@ -137,6 +137,7 @@ unsigned long long run_event_based_simulation_optimization_6(Inputs in, Simulati
 // GridInit.cu
 SimulationData grid_init_do_not_profile( Inputs in, int mype );
 SimulationData move_simulation_data_to_device( Inputs in, int mype, SimulationData SD );
+void release_device_memory(SimulationData GSD);
 
 // XSutils.cu
 int NGP_compare( const void * a, const void * b );


### PR DESCRIPTION
Hi there, our team has developed a memory profiler tool for GPU-accelerated applications. We found this app fails to release the GPU device memory after finishing the computation. I fixed it by adding a `release_device_memory(SimulationData GSD)` function. Could you please merge it?