### PR TITLE
Fixes for OpenMP on Microsoft Visual Studio

### DIFF
--- a/openmp-threading/GridInit.c
+++ b/openmp-threading/GridInit.c
@@ -11,6 +11,9 @@ SimulationData grid_init_do_not_profile( Inputs in, int mype )
 	// Set the initial seed value
 	uint64_t seed = 42;	
 
+	// loop variable 
+	long e = 0;
+	
 	////////////////////////////////////////////////////////////////////
 	// Initialize Nuclide Grids
 	////////////////////////////////////////////////////////////////////
@@ -135,7 +138,7 @@ SimulationData grid_init_do_not_profile( Inputs in, int mype )
 
 		// For each energy level in the hash table
 		#pragma omp parallel for
-		for( long e = 0; e < in.hash_bins; e++ )
+		for( e = 0; e < in.hash_bins; e++ )
 		{
 			double energy = e * du;
 

--- a/openmp-threading/Simulation.c
+++ b/openmp-threading/Simulation.c
@@ -41,8 +41,9 @@ unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int 
 	// Begin Actual Simulation Loop 
 	////////////////////////////////////////////////////////////////////////////////
 	unsigned long long verification = 0;
+	int i = 0;
 	#pragma omp parallel for schedule(dynamic,100) reduction(+:verification)
-	for( int i = 0; i < in.lookups; i++ )
+	for( i = 0; i < in.lookups; i++ )
 	{
 		#ifdef AML
 		int * num_nucs = aml_replicaset_hwloc_local_replica(SD.num_nucs_replica);
@@ -140,8 +141,9 @@ unsigned long long run_history_based_simulation(Inputs in, SimulationData SD, in
 	unsigned long long verification = 0;
 
 	// Begin outer lookup loop over particles. This loop is independent.
+	int p = 0;
 	#pragma omp parallel for schedule(dynamic, 100) reduction(+:verification)
-	for( int p = 0; p < in.particles; p++ )
+	for( p = 0; p < in.particles; p++ )
 	{
 		#ifdef AML
 		int * num_nucs = aml_replicaset_hwloc_local_replica(SD.num_nucs_replica);
@@ -706,6 +708,10 @@ unsigned long long run_event_based_simulation_optimization_1(Inputs in, Simulati
 	size_t sz;
 	size_t total_sz = 0;
 	double start, stop;
+	
+	// loop variables
+	int i = 0;
+	int m = 0;
 
 	sz = in.lookups * sizeof(double);
 	SD.p_energy_samples = (double *) malloc(sz);
@@ -727,7 +733,7 @@ unsigned long long run_event_based_simulation_optimization_1(Inputs in, Simulati
 	// Sample Materials and Energies
 	////////////////////////////////////////////////////////////////////////////////
 	#pragma omp parallel for schedule(dynamic, 100)
-	for( int i = 0; i < in.lookups; i++ )
+	for( i = 0; i < in.lookups; i++ )
 	{
 		// Set the initial seed value
 		uint64_t seed = STARTING_SEED;	
@@ -793,10 +799,10 @@ unsigned long long run_event_based_simulation_optimization_1(Inputs in, Simulati
 
 	// Individual Materials
 	offset = 0;
-	for( int m = 0; m < 12; m++ )
+	for( m = 0; m < 12; m++ )
 	{
 		#pragma omp parallel for schedule(dynamic,100) reduction(+:verification)
-		for( int i = offset; i < offset + num_samples_per_mat[m]; i++)
+		for( i = offset; i < offset + num_samples_per_mat[m]; i++)
 		{
 			#ifdef AML
 			int * num_nucs = aml_replicaset_hwloc_local_replica(SD.num_nucs_replica);

--- a/openmp-threading/XSbench_header.h
+++ b/openmp-threading/XSbench_header.h
@@ -5,12 +5,17 @@
 #include<stdlib.h>
 #include<time.h>
 #include<string.h>
-#include<strings.h>
 #include<math.h>
-#include<unistd.h>
-#include<sys/time.h>
 #include<assert.h>
 #include<stdint.h>
+
+#ifdef _MSC_VER
+#define strncasecmp _strnicmp
+#define strcasecmp _stricmp
+#else
+#include<unistd.h>
+#include<sys/time.h>
+#endif
 
 #ifdef OPENMP
 #include<omp.h>


### PR DESCRIPTION
With OpenMP on MSVC, you can’t declare the loop variable of a for loop inside the for statement.  i.e. this won’t work:
```
     #pragma omp parallel for schedule(dynamic, 100)
     for( int i = 0; i < in.lookups; i++ )
```
…but this is fine:
```
     int i;
     #pragma omp parallel for schedule(dynamic, 100)
     for(i = 0; i < in.lookups; i++ )
```

Also a couple other fixes for portability. 