### PR TITLE
Remove unnessesary copy for OpenMP offload

### DIFF
--- a/openmp-offload/Simulation.c
+++ b/openmp-offload/Simulation.c
@@ -48,8 +48,9 @@ unsigned long long run_event_based_simulation(Inputs in, SimulationData SD, int 
 	map(to: SD.mats[:SD.length_mats])\
 	map(to: SD.unionized_energy_array[:SD.length_unionized_energy_array])\
 	map(to: SD.index_grid[:SD.length_index_grid])\
-	map(to: SD.nuclide_grid[:SD.length_nuclide_grid])\
-  map(from: verification[:in.lookups])
+        map(to: in)\
+        map(from: verification[:in.lookups])\
+        defaultmap(none)
 	for( int i = 0; i < in.lookups; i++ )
 	{
 		// Set the initial seed value


### PR DESCRIPTION
The `Inputs` struct, `in`, is unnecessarily copied back to the host after execution of the target region.

This is minor and this fix has negligible performance improvement.

I additionally added a `defaultmap(none)` clause which enforces explicit data mapping at compile time, likely reducing the chance of similar oversights in the future.

I chose to map the entire struct instead of only the elements used in the target region, because it is faster in my experiments. The explanation is that copying the entire struct only initiates one HtoD memcpy call, whereas mapping each element would have initiated one for each struct element which turns out to be ~50% more expensive than copying a a few dozen extra bytes in a single memcpy call.